### PR TITLE
Fix currently selected date tap

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-date-picker",
-  "version": "1.3.4",
+  "version": "1.3.6",
   "authors": [
     "Ben Davis <bendavis78@gmail.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paper-date-picker",
-  "version": "1.3.4",
+  "version": "1.3.6",
   "description": "Provides a responsive date picker based on the material design spec",
   "main": "index.html",
   "devDependencies": {

--- a/paper-calendar.html
+++ b/paper-calendar.html
@@ -551,11 +551,12 @@
         }
 
         var item = event.model.item;
-        var newDate = new Date(this.date.getTime());
-        newDate.setDate(1);
-        newDate.setYear(item.year);
-        newDate.setMonth(item.month);
-        newDate.setDate(item.day);
+        var newDate = new Date(item.year, item.month, item.day);
+        if (this.date.getMilliseconds() === 0) {
+          // hack to make sure date comparison never gets equality
+          // so that tap on currently selected date worked as expected
+          newDate.setMilliseconds(1);
+        }
         this.currentDay = item.day;
         this.date = newDate;
       },


### PR DESCRIPTION
Following our recent talk with @afewyards about the algorithm of `_tapDay` function dealing with date update I found out that actually it is a bug according to our UX guides.

In original implementation that prevented **tap on currently selected date**. Date object remained **equal** to the previous one so that comparison didn't cause other updates. That was intentionally coded in this way with `newDate = new Date(oldDate.getTime())` and `newDate.setYear/Month/Date`.

In our UX that is not necessary. Moreover it is very important to make sure every tap causes update cycle. That's why I added an additional hack that checks for milliseconds and changes date object to make **equality check fail every time**.